### PR TITLE
Implemented API rate limit of no more than five requests in ten seconds.

### DIFF
--- a/whatapi/whatapi.py
+++ b/whatapi/whatapi.py
@@ -1,5 +1,6 @@
 from ConfigParser import ConfigParser
 import requests
+import time
 
 headers = {
     'Content-type': 'application/x-www-form-urlencoded',
@@ -54,6 +55,7 @@ class WhatAPI:
             params['authkey'] = self.authkey
             params['torrent_pass'] = self.passkey
         r = self.session.get(torrentpage, params=params, allow_redirects=False)
+        time.sleep(2)
         if r.status_code == 200 and 'application/x-bittorrent' in r.headers['content-type']:
             return r.content
         return None
@@ -67,6 +69,7 @@ class WhatAPI:
         params.update(kwargs)
 
         r = self.session.get(ajaxpage, params=params, allow_redirects=False)
+        time.sleep(2)
         try:
             json_response = r.json()
             if json_response["status"] != "success":


### PR DESCRIPTION
Per the [Gazelle API instructions](https://github.com/WhatCD/Gazelle/wiki/JSON-API-Documentation#unofficial-projects-that-utilize-the-api), requests should be limited to five per ten seconds.
