### PR TITLE
Config file parameter gets overwritten when creating ConfigParser object

### DIFF
--- a/whatapi/whatapi.py
+++ b/whatapi/whatapi.py
@@ -16,14 +16,14 @@ class RequestException(Exception):
 
 
 class WhatAPI:
-    def __init__(self, config=None, username=None, password=None, cookies=None):
+    def __init__(self, config_file=None, username=None, password=None, cookies=None):
         self.session = requests.Session()
         self.session.headers = headers
         self.authkey = None
         self.passkey = None
-        if config:
+        if config_file:
             config = ConfigParser()
-            config.read(config)
+            config.read(config_file)
             self.username = config.get('login', 'username')
             self.password = config.get('login', 'password')
         else:


### PR DESCRIPTION
Since we were re-using the 'config' variable name, the config file parameter was being overwritten when creating the ConfigParser object. Line 26 would throw a `TypeError: iteration over non-sequence` exception since it was trying to read from itself.

I'm not sure if you had a preference between re-naming the parameter or the ConfigParser object. Feel free to change it to match your style.
