### PR TITLE
Added Python3k support with alternative import of configparser

### DIFF
--- a/whatapi/whatapi.py
+++ b/whatapi/whatapi.py
@@ -1,4 +1,7 @@
-from ConfigParser import ConfigParser
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    import configparser as ConfigParser # py3k support
 import requests
 import time
 


### PR DESCRIPTION
I found out that the API throws an Exception when running under Py3k - this was caused by configparser. If now an ImportError happens (which happens in Py3k) it will try to import it the Py3k way.
So py2k and py3k are supported in one fork.