### PR TITLE
Fixed json error handling bug in whatapi.request()

### DIFF
--- a/whatapi/whatapi.py
+++ b/whatapi/whatapi.py
@@ -92,8 +92,13 @@ class WhatAPI:
         time.sleep(2)
         try:
             json_response = r.json()
-            if json_response["status"] != "success":
-                raise RequestException
-            return json_response
+            if "status" in json_response and json_response["status"] == "success":
+                return json_response
+            if "error" in json_response:
+                raise RequestException(json_response["error"])
+            if "status" in json_response:
+                raise RequestException(json_response["status"])
+            import pprint
+            raise RequestException(pprint.pformat(json_response))
         except ValueError:
             raise RequestException


### PR DESCRIPTION
If JSON call was returning non-success w/o an "error" member variable, the error was not given to the user and an unwanted exception was thrown.

Now, on non-success:
It first checks for an "error" member, and returns it if found
It then checks for a "status" member, and returns it if found
If neither are found, then the string-encapsulated JSON object is returned
