### PR TITLE
fix configparser/ConfigParser for python 3

### DIFF
--- a/whatapi/whatapi.py
+++ b/whatapi/whatapi.py
@@ -1,7 +1,7 @@
 try:
     from ConfigParser import ConfigParser
 except ImportError:
-    import configparser as ConfigParser # py3k support
+    from configparser import ConfigParser # py3k support
 import requests
 import time
 


### PR DESCRIPTION
- before this change, the code is attempting to do ConfigParser() on the module configparser (renamed to ConfigParser) which doesn't work because you're trying to call the module
- after this change, the ConfigParser method is imported from the configparser module, and so the call to ConfigParser() then works, as it is a method/function rather than a module