### PR TITLE
Allow users to extend and replace data payload.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Example usage:
 ::
 
     >>> import whatapi
-    >>> apihandle = whatapi.WhatAPI(username='me', password='secret')
+    >>> apihandle = whatapi.WhatAPI(username='me', password='secret', two_factor=None)
     >>> apihandle.request("browse", searchstr="Talulah Gosh")
     ...
     >>> apihandle.get_torrent(1234567)
@@ -28,7 +28,7 @@ To use another tracker:
 ::
 
     >>> import whatapi
-    >>> apihandle = whatapi.WhatAPI(username='me', password='secret',
+    >>> apihandle = whatapi.WhatAPI(username='me', password='secret', two_factor='actfast',
                                     server='https://passtheheadphones.me')
     >>> apihandle.request("browse", searchstr="The Beatles")
     ...

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Example usage:
 ::
 
     >>> import whatapi
-    >>> apihandle = whatapi.WhatAPI(username='me', password='secret', two_factor=None)
+    >>> apihandle = whatapi.WhatAPI(username='me', password='secret', update_payload={'qr_confirm': 'code'})
     >>> apihandle.request("browse", searchstr="Talulah Gosh")
     ...
     >>> apihandle.get_torrent(1234567)
@@ -28,7 +28,7 @@ To use another tracker:
 ::
 
     >>> import whatapi
-    >>> apihandle = whatapi.WhatAPI(username='me', password='secret', two_factor='actfast',
+    >>> apihandle = whatapi.WhatAPI(username='me', password='secret',
                                     server='https://passtheheadphones.me')
     >>> apihandle.request("browse", searchstr="The Beatles")
     ...

--- a/whatapi/whatapi.py
+++ b/whatapi/whatapi.py
@@ -21,23 +21,22 @@ class RequestException(Exception):
 
 class WhatAPI:
     def __init__(self, config_file=None, username=None, password=None, cookies=None,
-                 server="https://ssl.what.cd", throttler=None, two_factor=None):
+                 server="https://ssl.what.cd", throttler=None, update_payload={}):
         self.session = requests.Session()
         self.session.headers = headers
         self.authkey = None
         self.passkey = None
         self.server = server
         self.throttler = Throttler(5, 10) if throttler is None else throttler
+        self.update_payload = update_payload
         if config_file:
             config = ConfigParser()
             config.read(config_file)
             self.username = config.get('login', 'username')
             self.password = config.get('login', 'password')
-            self.two_factor = config.get('login', 'two_factor')
         else:
             self.username = username
             self.password = password
-            self.two_factor = two_factor
         if cookies:
             self.session.cookies = cookies
             try:
@@ -61,8 +60,7 @@ class WhatAPI:
                 'keeplogged': 1,
                 'login': 'Login'
         }
-        if self.two_factor is not None:
-            data['qrcode_confirm'] = self.two_factor
+        data.update(self.update_payload)
 
         r = self.session.post(loginpage, data=data, allow_redirects=False)
         if r.status_code != 302:

--- a/whatapi/whatapi.py
+++ b/whatapi/whatapi.py
@@ -21,7 +21,7 @@ class RequestException(Exception):
 
 class WhatAPI:
     def __init__(self, config_file=None, username=None, password=None, cookies=None,
-                 server="https://ssl.what.cd", throttler=None):
+                 server="https://ssl.what.cd", throttler=None, two_factor=None):
         self.session = requests.Session()
         self.session.headers = headers
         self.authkey = None
@@ -33,9 +33,11 @@ class WhatAPI:
             config.read(config_file)
             self.username = config.get('login', 'username')
             self.password = config.get('login', 'password')
+            self.two_factor = config.get('login', 'two_factor')
         else:
             self.username = username
             self.password = password
+            self.two_factor = two_factor
         if cookies:
             self.session.cookies = cookies
             try:
@@ -59,6 +61,9 @@ class WhatAPI:
                 'keeplogged': 1,
                 'login': 'Login'
         }
+        if self.two_factor is not None:
+            data['qrcode_confirm'] = self.two_factor
+
         r = self.session.post(loginpage, data=data, allow_redirects=False)
         if r.status_code != 302:
             raise LoginException


### PR DESCRIPTION
Forked / extended versions of the whatAPI may add fields to login, for example for 2fa.
Allow arbitrary update to payload sent to login.